### PR TITLE
Refactor Project Folder Structure

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,5 @@
       "Hello World",
       "Serverless API"
     ],
-    "_templates_repo": "https://github.com/aws-samples/aws-sam-swift"
+    "_templates_repo": "https://github.com/dave-moser/aws-sam-swift"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,8 +1,8 @@
 {
-    "project_name": "My Swift Project",
+    "project_name": "my-swift-project",
     "template": [
       "Hello World",
       "Serverless API"
     ],
-    "_templates_repo": "https://github.com/dave-moser/aws-sam-swift"
+    "_templates_repo": "https://github.com/aws-samples/aws-sam-swift"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -37,7 +37,7 @@ def main():
         templates_repo,
         directory=template_dir,
         no_input=True,
-        output_dir="..",
+        output_dir=f"./{project_name}/",
         overwrite_if_exists=True,
         extra_context={
             "project_name": project_name,

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,6 +1,5 @@
 import os
 import platform
-import shutil
 from cookiecutter.main import cookiecutter
 
 def get_architecture() -> str:
@@ -13,21 +12,13 @@ def get_architecture() -> str:
     else:
         return arch
 
-def remove_parent_project_folder(project_name: str):
-
-    try:
-        dirpath = os.path.join('../', project_name)
-        shutil.rmtree(dirpath, ignore_errors=True)
-    except:
-        print(f'Could not delete the parent folder: {project_name}. Please remove manually.')
-
 def main():
 
     project_name = "{{ cookiecutter.project_name }}"
     
     template = "{{ cookiecutter.template }}"
 
-    project_slug = project_name.lower().replace(' ', '-')
+    project_slug = template.lower().replace(' ', '-')
     architecture = get_architecture()
 
     templates_repo = "{{ cookiecutter._templates_repo }}"
@@ -37,7 +28,7 @@ def main():
         templates_repo,
         directory=template_dir,
         no_input=True,
-        output_dir=f"./{project_name}/",
+        output_dir=".",
         overwrite_if_exists=True,
         extra_context={
             "project_name": project_name,
@@ -46,23 +37,20 @@ def main():
         }
     )
 
-    # remove the temporary parent folder
-    remove_parent_project_folder(project_name)
-
     print()
     print("-----------------------")
     print("Generating application:")
     print("-----------------------")
     print(f"Name: {project_name}")
-    print(f"Folder: {project_slug}")
+    print(f"Folder: {project_name}/{project_slug}")
     print(f"Runtime: swift 5.8")
     print(f"Architecture: {architecture}")
     print(f"Dependency Manager: spm")
     print(f"Application Template: {template}")
     print()
-    print("Project initialized successfully! You can now jump to the {} folder.".format(project_slug))
+    print(f"Project initialized successfully! You can now jump to the {project_name}/{project_slug} folder.")
     print()
-    print(f"Next steps can be found in the README file at {project_slug}/README.md")
+    print(f"Next steps can be found in the README file at {project_name}/{project_slug}/README.md")
     print()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Refactor the folder structure to create a folder for the project-name with a sub-folder for the template type. This avoids having to delete the default project folder created by cookiecutter which was problematic on Windows.
